### PR TITLE
Bumped version and unlocked application to use Chef 12 fix in 4.1.6

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "16.0.0"
+version          "16.1.0"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb
 end
 
-depends "application", "~> 3.0"
+depends "application"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "16.1.0"
+version          "16.2.0"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb


### PR DESCRIPTION
Bumped version and unlocked application to use Chef 12 fix in Application 4.1.6

Without this, we will get application errors when we try to run this with Chef 12.
